### PR TITLE
Add full-stack JWT auth example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,85 @@
-# app_developement
-pwa based web application
+# PWA Authentication Starter
+
+This repository contains a minimal Progressive Web App authentication example built with **React (Vite)** on the frontend and **Node.js + Express + MySQL** on the backend. It demonstrates how to create a signup/login flow that stores a JWT in `localStorage` and guards protected routes on both the client and the server.
+
+## Project structure
+
+```
+app_developement/
+├── frontend/   # React + Vite client
+└── backend/    # Express + MySQL API
+```
+
+## Getting started
+
+### Prerequisites
+
+* Node.js 18+
+* pnpm / npm / yarn
+* MySQL 8 (phpMyAdmin optional but recommended)
+
+### Backend setup
+
+1. Copy the environment template and update the variables with your MySQL credentials and desired JWT secret:
+
+   ```bash
+   cd backend
+   cp .env.example .env
+   # Edit .env as needed
+   ```
+
+2. Install dependencies and start the API server:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+   The server automatically ensures the `users` table exists before listening on the configured `PORT` (default `4000`).
+
+### Frontend setup
+
+1. Install dependencies and start the Vite dev server:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+2. Create a `VITE_API_URL` environment variable (for example in `frontend/.env`) that points to the backend base URL. By default the frontend falls back to `http://localhost:4000/api`.
+
+3. Open the printed URL (default `http://localhost:5173`) in your browser. You can register a new account, log in, and you will be redirected to the protected welcome page. The JWT is stored in `localStorage` to persist the session.
+
+### Database schema
+
+The backend automatically creates the required table when it starts, but you can also run the SQL manually in phpMyAdmin or the MySQL CLI:
+
+```sql
+CREATE TABLE IF NOT EXISTS users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+## API overview
+
+| Method | Endpoint   | Description                       |
+|--------|------------|-----------------------------------|
+| POST   | `/api/signup`  | Creates a new user account.        |
+| POST   | `/api/login`   | Authenticates a user and returns a JWT. |
+| GET    | `/api/profile` | Returns the authenticated user profile. |
+
+All protected requests require an `Authorization: Bearer <token>` header that contains the JWT returned from the login endpoint.
+
+## Security considerations
+
+* Passwords are hashed using `bcrypt` before being stored in the database.
+* JWTs expire after 24 hours; adjust the `TOKEN_TTL_SECONDS` constant if needed.
+* Remember to use HTTPS in production so that tokens are transmitted securely.
+
+## Progressive Web App considerations
+
+You can extend this starter by adding a service worker and manifest to turn the React app into a full PWA. The current setup focuses on authentication and provides a solid base for further enhancements.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+PORT=4000
+CLIENT_ORIGIN=http://localhost:5173
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=your_password
+DB_NAME=pwa_auth
+JWT_SECRET=super_secret_jwt_key

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pwa-auth-backend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "nodemon src/server.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "jsonwebtoken": "^9.0.2",
+    "mysql2": "^3.9.4"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import cors from 'cors';
+import authRoutes from './routes/authRoutes.js';
+import profileRoutes from './routes/profileRoutes.js';
+
+// Configure and return the Express app instance.
+export const createApp = () => {
+  const app = express();
+
+  app.use(cors({ origin: process.env.CLIENT_ORIGIN || 'http://localhost:5173', credentials: false }));
+  app.use(express.json());
+
+  app.use('/api', authRoutes);
+  app.use('/api', profileRoutes);
+
+  // Global error handler to avoid leaking implementation details.
+  app.use((err, req, res, next) => {
+    console.error(err);
+    res.status(err.status || 500).json({ message: err.message || 'Internal server error' });
+  });
+
+  return app;
+};

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,0 +1,22 @@
+import mysql from 'mysql2/promise';
+
+// Create a lazily-initialised connection pool that uses environment variables for configuration.
+// The pool is shared between requests to avoid creating new connections for each query.
+let pool;
+
+export const getPool = () => {
+  if (!pool) {
+    pool = mysql.createPool({
+      host: process.env.DB_HOST,
+      port: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      waitForConnections: true,
+      connectionLimit: 10,
+      queueLimit: 0
+    });
+  }
+
+  return pool;
+};

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,73 @@
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { getPool } from '../config/database.js';
+
+const TOKEN_TTL_SECONDS = 60 * 60 * 24; // 24 hours
+
+const getJwtSecret = () => {
+  if (!process.env.JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is not set.');
+  }
+  return process.env.JWT_SECRET;
+};
+
+const createToken = (payload) =>
+  jwt.sign(payload, getJwtSecret(), {
+    expiresIn: TOKEN_TTL_SECONDS
+  });
+
+// Handles POST /signup. Creates a new account when the email is not already registered.
+export const signup = async (req, res, next) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required.' });
+  }
+
+  try {
+    const pool = getPool();
+
+    const [existingRows] = await pool.query('SELECT id FROM users WHERE email = ?', [email]);
+    if (existingRows.length > 0) {
+      return res.status(409).json({ message: 'An account with that email already exists.' });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    await pool.query('INSERT INTO users (email, password_hash) VALUES (?, ?)', [email, passwordHash]);
+
+    return res.status(201).json({ message: 'Account created successfully.' });
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// Handles POST /login. Verifies credentials and returns a signed JWT when valid.
+export const login = async (req, res, next) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required.' });
+  }
+
+  try {
+    const pool = getPool();
+    const [rows] = await pool.query('SELECT id, password_hash FROM users WHERE email = ?', [email]);
+
+    if (rows.length === 0) {
+      return res.status(401).json({ message: 'Invalid email or password.' });
+    }
+
+    const user = rows[0];
+    const isPasswordValid = await bcrypt.compare(password, user.password_hash);
+
+    if (!isPasswordValid) {
+      return res.status(401).json({ message: 'Invalid email or password.' });
+    }
+
+    const token = createToken({ userId: user.id, email });
+    return res.json({ token });
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/controllers/profileController.js
+++ b/backend/src/controllers/profileController.js
@@ -1,0 +1,17 @@
+import { getPool } from '../config/database.js';
+
+// Handles GET /profile. Returns the authenticated user's public profile data.
+export const getProfile = async (req, res, next) => {
+  try {
+    const pool = getPool();
+    const [rows] = await pool.query('SELECT id, email, created_at FROM users WHERE id = ?', [req.user.userId]);
+
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'User not found.' });
+    }
+
+    return res.json(rows[0]);
+  } catch (error) {
+    return next(error);
+  }
+};

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,0 +1,19 @@
+import jwt from 'jsonwebtoken';
+
+// Express middleware that validates the Authorization header and attaches the user payload to the request.
+export const authenticate = (req, res, next) => {
+  const header = req.headers.authorization || '';
+  const [, token] = header.split(' ');
+
+  if (!token) {
+    return res.status(401).json({ message: 'Authentication token missing.' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    return next();
+  } catch (error) {
+    return res.status(401).json({ message: 'Invalid or expired token.' });
+  }
+};

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { login, signup } from '../controllers/authController.js';
+
+const router = Router();
+
+router.post('/signup', signup);
+router.post('/login', login);
+
+export default router;

--- a/backend/src/routes/profileRoutes.js
+++ b/backend/src/routes/profileRoutes.js
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getProfile } from '../controllers/profileController.js';
+import { authenticate } from '../middleware/authMiddleware.js';
+
+const router = Router();
+
+router.get('/profile', authenticate, getProfile);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,22 @@
+import dotenv from 'dotenv';
+import { createApp } from './app.js';
+import { ensureUsersTable } from './utils/bootstrap.js';
+
+dotenv.config();
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 4000;
+
+const startServer = async () => {
+  try {
+    await ensureUsersTable();
+    const app = createApp();
+    app.listen(PORT, () => {
+      console.log(`API server listening on port ${PORT}`);
+    });
+  } catch (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/backend/src/utils/bootstrap.js
+++ b/backend/src/utils/bootstrap.js
@@ -1,0 +1,22 @@
+import { getPool } from '../config/database.js';
+
+const CREATE_USERS_TABLE = `
+  CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+`;
+
+// Ensures that the expected users table exists before the API starts handling requests.
+export const ensureUsersTable = async () => {
+  const pool = getPool();
+  const connection = await pool.getConnection();
+  try {
+    await connection.query(CREATE_USERS_TABLE);
+    console.log('Users table is ready');
+  } finally {
+    connection.release();
+  }
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PWA Auth Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pwa-auth-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+import AuthPage from './pages/AuthPage.jsx';
+import WelcomePage from './pages/WelcomePage.jsx';
+
+// A thin wrapper around routes that ensures a valid session token exists.
+const ProtectedRoute = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  return isAuthenticated ? children : <Navigate to="/" replace />;
+};
+
+// The root component wires together the auth provider and route tree.
+const App = () => (
+  <AuthProvider>
+    <div className="app-container">
+      <Routes>
+        <Route path="/" element={<AuthPage />} />
+        <Route
+          path="/welcome"
+          element={
+            <ProtectedRoute>
+              <WelcomePage />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </div>
+  </AuthProvider>
+);
+
+export default App;

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+const TOKEN_KEY = 'pwa-auth-token';
+
+// Provider component that stores the authenticated user token and exposes helper functions.
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem(TOKEN_KEY));
+
+  // Whenever the token changes, update localStorage so the session persists across refreshes.
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem(TOKEN_KEY, token);
+    } else {
+      localStorage.removeItem(TOKEN_KEY);
+    }
+  }, [token]);
+
+  const value = useMemo(
+    () => ({
+      token,
+      isAuthenticated: Boolean(token),
+      login: setToken,
+      logout: () => setToken(null)
+    }),
+    [token]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+// Hook used across the app to access the auth state.
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './styles.css';
+
+// Entrypoint for the React application. Wraps the App component with the router.
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AuthPage.jsx
+++ b/frontend/src/pages/AuthPage.jsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
+
+// Authentication page that presents a combined login/signup form.
+const AuthPage = () => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [isSignup, setIsSignup] = useState(false);
+  const [formData, setFormData] = useState({ email: '', password: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Handles changes for both the email and password inputs.
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  // Swap the UI between signup and login modes.
+  const toggleMode = () => {
+    setError('');
+    setSuccess('');
+    setIsSignup((prev) => !prev);
+  };
+
+  // Submit handler that calls either the signup or login endpoint based on the mode.
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const endpoint = isSignup ? '/signup' : '/login';
+      const response = await axios.post(`${API_BASE_URL}${endpoint}`, formData);
+
+      if (isSignup) {
+        setSuccess('Signup successful! You can now log in.');
+        setIsSignup(false);
+        setFormData({ email: formData.email, password: '' });
+      } else {
+        const { token } = response.data;
+        login(token);
+        navigate('/welcome');
+      }
+    } catch (err) {
+      const message = err.response?.data?.message || 'Something went wrong. Please try again.';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h1>{isSignup ? 'Create your account' : 'Welcome back'}</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          name="email"
+          value={formData.email}
+          onChange={handleChange}
+          placeholder="Email address"
+          required
+          autoComplete="email"
+        />
+        <input
+          type="password"
+          name="password"
+          value={formData.password}
+          onChange={handleChange}
+          placeholder="Password"
+          required
+          minLength={8}
+          autoComplete={isSignup ? 'new-password' : 'current-password'}
+        />
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Please wait…' : isSignup ? 'Sign up' : 'Log in'}
+        </button>
+      </form>
+      {error && <p className="error-message">{error}</p>}
+      {success && <p className="success-message">{success}</p>}
+      <p className="toggle">
+        {isSignup ? 'Already have an account?' : "Don't have an account?"}
+        <button type="button" onClick={toggleMode} disabled={isSubmitting} className="link-button">
+          {isSignup ? 'Log in' : 'Sign up'}
+        </button>
+      </p>
+    </div>
+  );
+};
+
+export default AuthPage;

--- a/frontend/src/pages/WelcomePage.jsx
+++ b/frontend/src/pages/WelcomePage.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext.jsx';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000/api';
+
+// Protected welcome page that fetches the user profile using the stored JWT.
+const WelcomePage = () => {
+  const { token, logout } = useAuth();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      try {
+        const response = await axios.get(`${API_BASE_URL}/profile`, {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+        setProfile(response.data);
+      } catch (err) {
+        setError('Session expired. Please log in again.');
+        logout();
+        navigate('/', { replace: true });
+      }
+    };
+
+    fetchProfile();
+  }, [token, logout, navigate]);
+
+  const handleLogout = () => {
+    logout();
+    navigate('/', { replace: true });
+  };
+
+  return (
+    <div className="card">
+      <h1>Welcome!</h1>
+      {profile ? (
+        <>
+          <p className="success-message">You are logged in as {profile.email}.</p>
+          <p>Account created on: {new Date(profile.created_at).toLocaleString()}</p>
+        </>
+      ) : (
+        !error && <p>Loading profile…</p>
+      )}
+      {error && <p className="error-message">{error}</p>}
+      <button type="button" onClick={handleLogout}>
+        Log out
+      </button>
+    </div>
+  );
+};
+
+export default WelcomePage;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,90 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f3f4f6;
+  color: #111827;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+}
+
+.app-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.card {
+  width: min(420px, 100%);
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 20px 25px -15px rgba(15, 23, 42, 0.25);
+  padding: 2.5rem 2rem;
+}
+
+.card h1 {
+  margin-top: 0;
+  text-align: center;
+}
+
+.card form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+input[type='email'],
+input[type='password'] {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.toggle {
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.toggle button {
+  margin-left: 0.35rem;
+}
+
+.link-button {
+  background: transparent;
+  color: #2563eb;
+  padding: 0;
+}
+
+.success-message {
+  color: #047857;
+  text-align: center;
+}
+
+.error-message {
+  color: #b91c1c;
+  text-align: center;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Vite configuration for the PWA authentication frontend.
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- add a Vite-powered React frontend with combined login/signup flow, welcome page, and client-side JWT session handling
- implement Express API with MySQL integration, bcrypt password hashing, JWT issuance, and protected profile route
- document environment setup, database schema, and project usage in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d77d8cc2688326a18cec9cbaa0789e