### PR TITLE
Add full-stack PWA authentication system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# app_developement
-pwa based web application
+# PWA Authentication Demo
+
+Full-stack Progressive Web App demonstrating a modern authentication flow with a React (Vite) frontend and a Node.js + Express + MySQL backend.
+
+## Getting Started
+
+### Backend
+
+1. Copy the environment template:
+
+   ```bash
+   cd backend
+   cp .env.example .env
+   ```
+
+2. Update `.env` with your database and email credentials.
+
+3. Create the required MySQL table:
+
+   ```sql
+   CREATE TABLE users (
+     id INT AUTO_INCREMENT PRIMARY KEY,
+     email VARCHAR(255) NULL,
+     mobile_number VARCHAR(25) NULL,
+     password_hash VARCHAR(255) NOT NULL,
+     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+   );
+   ```
+
+4. Install dependencies and start the API server:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+### Frontend
+
+1. Install dependencies and start the development server:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+2. The app expects the backend to run on `http://localhost:5000` by default. Override with `VITE_API_BASE_URL` if needed.
+
+### Features
+
+- Responsive split-screen layout with modern styling.
+- Signup, login, remember-me, and password reset request flows.
+- JWT-protected profile endpoint.
+- Password hashing with bcrypt and transactional email via Nodemailer.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,11 @@
+PORT=5000
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=your_password
+DB_NAME=pwa_auth
+JWT_SECRET=supersecretjwt
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USER=user@example.com
+EMAIL_PASS=your_email_password
+CLIENT_URL=http://localhost:5173

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pwa-auth-backend",
+  "version": "1.0.0",
+  "description": "Express backend for PWA authentication",
+  "main": "src/server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js"
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "mysql2": "^3.11.3",
+    "nodemailer": "^6.9.12"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.4"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,24 @@
+import cors from 'cors';
+import express from 'express';
+import authRoutes from './routes/authRoutes.js';
+
+const app = express();
+
+app.use(cors({
+  origin: process.env.CLIENT_URL || 'http://localhost:5173',
+  credentials: true
+}));
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ status: 'OK', message: 'PWA Auth API' });
+});
+
+app.use('/', authRoutes);
+
+app.use((err, req, res, next) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ message: 'Internal server error.' });
+});
+
+export default app;

--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,0 +1,27 @@
+import mysql from 'mysql2/promise';
+
+const createPool = () => {
+  const pool = mysql.createPool({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0
+  });
+
+  return pool;
+};
+
+export const pool = createPool();
+
+export const testConnection = async () => {
+  try {
+    await pool.getConnection();
+    console.log('✅ Connected to MySQL database');
+  } catch (error) {
+    console.error('❌ Database connection failed:', error.message);
+    throw error;
+  }
+};

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,133 @@
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import { pool } from '../config/db.js';
+import { sendResetEmail } from '../utils/email.js';
+
+const generateToken = (payload, expiresIn = '7d') =>
+  jwt.sign(payload, process.env.JWT_SECRET, { expiresIn });
+
+export const signup = async (req, res) => {
+  const { email, mobileNumber, password, confirmPassword } = req.body;
+
+  try {
+    if (!email && !mobileNumber) {
+      return res.status(400).json({ message: 'Email or mobile number is required.' });
+    }
+
+    if (!password || password.length < 6) {
+      return res.status(400).json({ message: 'Password must be at least 6 characters long.' });
+    }
+
+    if (password !== confirmPassword) {
+      return res.status(400).json({ message: 'Passwords do not match.' });
+    }
+
+    const [existing] = await pool.execute(
+      'SELECT id FROM users WHERE email = ? OR mobile_number = ?',
+      [email || null, mobileNumber || null]
+    );
+
+    if (existing.length > 0) {
+      return res.status(409).json({ message: 'An account with that email or mobile already exists.' });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+
+    await pool.execute(
+      'INSERT INTO users (email, mobile_number, password_hash, created_at) VALUES (?, ?, ?, NOW())',
+      [email || null, mobileNumber || null, passwordHash]
+    );
+
+    return res.status(201).json({ message: 'Account created successfully. Please sign in.' });
+  } catch (error) {
+    console.error('Signup error:', error);
+    return res.status(500).json({ message: 'Failed to create account. Please try again later.' });
+  }
+};
+
+export const login = async (req, res) => {
+  const { identifier, password } = req.body;
+
+  try {
+    if (!identifier || !password) {
+      return res.status(400).json({ message: 'Identifier and password are required.' });
+    }
+
+    const [rows] = await pool.execute(
+      'SELECT id, email, mobile_number, password_hash FROM users WHERE email = ? OR mobile_number = ? LIMIT 1',
+      [identifier, identifier]
+    );
+
+    if (rows.length === 0) {
+      return res.status(401).json({ message: 'Invalid credentials.' });
+    }
+
+    const user = rows[0];
+    const match = await bcrypt.compare(password, user.password_hash);
+
+    if (!match) {
+      return res.status(401).json({ message: 'Invalid credentials.' });
+    }
+
+    const token = generateToken({ id: user.id, email: user.email });
+
+    return res.status(200).json({
+      message: 'Login successful.',
+      token,
+      user: {
+        id: user.id,
+        email: user.email,
+        mobileNumber: user.mobile_number
+      }
+    });
+  } catch (error) {
+    console.error('Login error:', error);
+    return res.status(500).json({ message: 'Failed to sign in. Please try again later.' });
+  }
+};
+
+export const profile = async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const [rows] = await pool.execute(
+      'SELECT id, email, mobile_number, created_at FROM users WHERE id = ? LIMIT 1',
+      [userId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'User not found.' });
+    }
+
+    return res.status(200).json({ user: rows[0] });
+  } catch (error) {
+    console.error('Profile error:', error);
+    return res.status(500).json({ message: 'Failed to retrieve profile.' });
+  }
+};
+
+export const resetPassword = async (req, res) => {
+  const { email } = req.body;
+
+  try {
+    if (!email) {
+      return res.status(400).json({ message: 'Email is required to reset password.' });
+    }
+
+    const [rows] = await pool.execute('SELECT id, email FROM users WHERE email = ? LIMIT 1', [email]);
+
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'No account found with that email.' });
+    }
+
+    const user = rows[0];
+    const resetToken = generateToken({ id: user.id }, '1h');
+    const resetLink = `${process.env.CLIENT_URL}/reset-password?token=${resetToken}`;
+
+    await sendResetEmail({ to: email, link: resetLink });
+
+    return res.status(200).json({ message: 'Password reset email sent successfully.' });
+  } catch (error) {
+    console.error('Reset password error:', error);
+    return res.status(500).json({ message: 'Failed to send reset password email.' });
+  }
+};

--- a/backend/src/middleware/authMiddleware.js
+++ b/backend/src/middleware/authMiddleware.js
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+
+export const authenticate = (req, res, next) => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authorization header missing or invalid.' });
+  }
+
+  const token = authHeader.split(' ')[1];
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    return next();
+  } catch (error) {
+    console.error('JWT verification failed:', error);
+    return res.status(401).json({ message: 'Invalid or expired token.' });
+  }
+};

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { authenticate } from '../middleware/authMiddleware.js';
+import { login, profile, resetPassword, signup } from '../controllers/authController.js';
+
+const router = Router();
+
+router.post('/signup', signup);
+router.post('/login', login);
+router.get('/profile', authenticate, profile);
+router.post('/reset-password', resetPassword);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,21 @@
+import dotenv from 'dotenv';
+import app from './app.js';
+import { testConnection } from './config/db.js';
+
+dotenv.config();
+
+const PORT = process.env.PORT || 5000;
+
+const startServer = async () => {
+  try {
+    await testConnection();
+    app.listen(PORT, () => {
+      console.log(`🚀 Server is running on port ${PORT}`);
+    });
+  } catch (error) {
+    console.error('Failed to start server:', error.message);
+    process.exit(1);
+  }
+};
+
+startServer();

--- a/backend/src/utils/email.js
+++ b/backend/src/utils/email.js
@@ -1,0 +1,27 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.EMAIL_HOST,
+  port: Number(process.env.EMAIL_PORT || 587),
+  secure: false,
+  auth: {
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASS
+  }
+});
+
+export const sendResetEmail = async ({ to, link }) => {
+  const message = {
+    from: `No Reply <${process.env.EMAIL_USER}>`,
+    to,
+    subject: 'Reset your password',
+    html: `
+      <p>You requested to reset your password.</p>
+      <p>Click the link below to set a new password. This link expires in 1 hour.</p>
+      <p><a href="${link}">${link}</a></p>
+      <p>If you did not request this, you can safely ignore this email.</p>
+    `
+  };
+
+  await transporter.sendMail(message);
+};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PWA Auth</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "PWA Auth",
+  "short_name": "Auth",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#25293c",
+  "theme_color": "#7367f0",
+  "icons": []
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pwa-auth-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "prop-types": "^15.8.1",
+    "react-icons": "^5.2.1",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.8",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "vite": "^5.4.9"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,243 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f5f8;
+  color: #2f3349;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f5f5f8 0%, #e7e7f0 50%, #f5f5f8 100%);
+}
+
+a {
+  color: #7367f0;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.auth-container {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  min-height: 100vh;
+}
+
+.auth-illustration {
+  background-color: #25293c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.auth-illustration img {
+  max-width: 100%;
+  height: auto;
+}
+
+.auth-form {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.auth-card {
+  width: min(420px, 100%);
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 2.5rem;
+  box-shadow: 0 30px 60px rgba(115, 103, 240, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.auth-logo img {
+  width: 48px;
+  height: 48px;
+}
+
+.auth-header h1 {
+  margin: 0;
+  font-size: 2rem;
+  color: #2f3349;
+}
+
+.auth-header p {
+  margin: 0.25rem 0 0;
+  color: #7a7f9a;
+  font-size: 0.95rem;
+}
+
+.auth-form-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-control label {
+  font-weight: 600;
+  color: #4a5073;
+}
+
+.form-control input {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #d8d6de;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-control input:focus {
+  outline: none;
+  border-color: #7367f0;
+  box-shadow: 0 0 0 4px rgba(115, 103, 240, 0.12);
+}
+
+.password-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-field input {
+  width: 100%;
+  padding-right: 2.75rem;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #7a7f9a;
+  font-size: 1.1rem;
+  display: grid;
+  place-items: center;
+}
+
+.password-toggle:hover {
+  color: #7367f0;
+}
+
+.form-options {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: #6f7391;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.checkbox input {
+  width: 16px;
+  height: 16px;
+}
+
+.primary-button {
+  background: #7367f0;
+  color: #ffffff;
+  border: none;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 30px rgba(115, 103, 240, 0.25);
+}
+
+.primary-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.status-message {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.9rem;
+}
+
+.status-message.error {
+  background: rgba(255, 86, 48, 0.1);
+  color: #d64c42;
+}
+
+.status-message.success {
+  background: rgba(40, 199, 111, 0.12);
+  color: #28c76f;
+}
+
+.auth-footer {
+  text-align: center;
+  color: #6f7391;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 1024px) {
+  .auth-container {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-illustration {
+    min-height: 240px;
+  }
+
+  .auth-form {
+    padding: 1.5rem;
+  }
+
+  .auth-card {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    background: #ffffff;
+  }
+
+  .auth-illustration {
+    padding: 1.5rem;
+    min-height: 180px;
+  }
+
+  .auth-card {
+    padding: 1.75rem;
+    border-radius: 18px;
+  }
+
+  .auth-header h1 {
+    font-size: 1.75rem;
+  }
+
+  .primary-button {
+    width: 100%;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,15 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import LoginPage from './pages/Login.jsx';
+import SignupPage from './pages/Signup.jsx';
+
+const App = () => {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/signup" element={<SignupPage />} />
+      <Route path="*" element={<Navigate to="/login" replace />} />
+    </Routes>
+  );
+};
+
+export default App;

--- a/frontend/src/assets/demo-image.svg
+++ b/frontend/src/assets/demo-image.svg
@@ -1,0 +1,10 @@
+<svg width="640" height="640" viewBox="0 0 640 640" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="640" rx="48" fill="#2F3349"/>
+  <circle cx="200" cy="220" r="110" fill="#7367F0" opacity="0.65"/>
+  <circle cx="440" cy="380" r="140" fill="#7367F0" opacity="0.4"/>
+  <path d="M180 320H460C490.928 320 516 345.072 516 376V460C516 490.928 490.928 516 460 516H180C149.072 516 124 490.928 124 460V376C124 345.072 149.072 320 180 320Z" fill="#403C64"/>
+  <rect x="220" y="360" width="120" height="36" rx="12" fill="#7367F0"/>
+  <rect x="360" y="360" width="80" height="36" rx="12" fill="#7367F0" opacity="0.6"/>
+  <rect x="220" y="412" width="220" height="20" rx="10" fill="#5B5F7A"/>
+  <rect x="220" y="444" width="160" height="20" rx="10" fill="#5B5F7A" opacity="0.6"/>
+</svg>

--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,0 +1,5 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="16" fill="#7367F0"/>
+  <path d="M20 32C20 25.3726 25.3726 20 32 20C38.6274 20 44 25.3726 44 32C44 38.6274 38.6274 44 32 44" stroke="white" stroke-width="4" stroke-linecap="round"/>
+  <path d="M24 36C24 32.6863 26.6863 30 30 30H34C37.3137 30 40 32.6863 40 36" stroke="white" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/components/AuthLayout.jsx
+++ b/frontend/src/components/AuthLayout.jsx
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import logo from '../assets/logo.svg';
+import demoImage from '../assets/demo-image.svg';
+
+const AuthLayout = ({ title, subtitle, children, footer }) => {
+  return (
+    <div className="auth-container">
+      <div className="auth-illustration">
+        <img src={demoImage} alt="Demo" />
+      </div>
+      <div className="auth-form">
+        <div className="auth-card">
+          <div className="auth-logo">
+            <Link to="/">
+              <img src={logo} alt="Demo logo" />
+            </Link>
+          </div>
+          <div className="auth-header">
+            <h1>{title}</h1>
+            <p>{subtitle}</p>
+          </div>
+          {children}
+          <div className="auth-footer">{footer}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+AuthLayout.propTypes = {
+  title: PropTypes.string.isRequired,
+  subtitle: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  footer: PropTypes.node
+};
+
+AuthLayout.defaultProps = {
+  footer: null
+};
+
+export default AuthLayout;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { FiEye, FiEyeOff } from 'react-icons/fi';
+import { Link } from 'react-router-dom';
+import AuthLayout from '../components/AuthLayout.jsx';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+
+const LoginPage = () => {
+  const [formData, setFormData] = useState({
+    identifier: '',
+    password: '',
+    remember: false
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState({ type: null, message: '' });
+
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: type === 'checkbox' ? checked : value
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setStatus({ type: null, message: '' });
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          identifier: formData.identifier,
+          password: formData.password
+        })
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Unable to sign in.');
+      }
+
+      const storage = formData.remember ? localStorage : sessionStorage;
+      storage.setItem('authToken', data.token);
+
+      setStatus({ type: 'success', message: 'Login successful! Token stored.' });
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthLayout
+      title="Welcome Back"
+      subtitle="Please sign in to continue"
+      footer={
+        <p>
+          New on our platform? <Link to="/signup">Create an account</Link>
+        </p>
+      }
+    >
+      <form className="auth-form-body" onSubmit={handleSubmit}>
+        <div className="form-control">
+          <label htmlFor="identifier">Email or Mobile Number</label>
+          <input
+            id="identifier"
+            name="identifier"
+            type="text"
+            placeholder="Enter your email or mobile"
+            value={formData.identifier}
+            onChange={handleChange}
+            required
+          />
+        </div>
+
+        <div className="form-control">
+          <label htmlFor="password">Password</label>
+          <div className="password-field">
+            <input
+              id="password"
+              name="password"
+              type={showPassword ? 'text' : 'password'}
+              placeholder="Enter your password"
+              value={formData.password}
+              onChange={handleChange}
+              required
+            />
+            <button
+              type="button"
+              className="password-toggle"
+              onClick={() => setShowPassword((prev) => !prev)}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              {showPassword ? <FiEyeOff /> : <FiEye />}
+            </button>
+          </div>
+        </div>
+
+        <div className="form-options">
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              name="remember"
+              checked={formData.remember}
+              onChange={handleChange}
+            />
+            Remember Me
+          </label>
+          <a className="reset-link" href="/reset-password">
+            Reset Password?
+          </a>
+        </div>
+
+        {status.message && (
+          <p className={`status-message ${status.type}`}>{status.message}</p>
+        )}
+
+        <button type="submit" className="primary-button" disabled={loading}>
+          {loading ? 'Signing In…' : 'Login'}
+        </button>
+      </form>
+    </AuthLayout>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import { FiEye, FiEyeOff } from 'react-icons/fi';
+import { Link, useNavigate } from 'react-router-dom';
+import AuthLayout from '../components/AuthLayout.jsx';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+
+const SignupPage = () => {
+  const navigate = useNavigate();
+  const [formData, setFormData] = useState({
+    email: '',
+    mobileNumber: '',
+    password: '',
+    confirmPassword: ''
+  });
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState({ type: null, message: '' });
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setStatus({ type: null, message: '' });
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'Unable to create account.');
+      }
+
+      setStatus({ type: 'success', message: data.message });
+      setTimeout(() => navigate('/login'), 1200);
+    } catch (error) {
+      setStatus({ type: 'error', message: error.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthLayout
+      title="Sign Up"
+      subtitle="Make your app management easy and fun!"
+      footer={
+        <p>
+          Already have an account? <Link to="/login">Sign In</Link>
+        </p>
+      }
+    >
+      <form className="auth-form-body" onSubmit={handleSubmit}>
+        <div className="form-control">
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="Enter your email"
+            value={formData.email}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="form-control">
+          <label htmlFor="mobileNumber">Mobile Number</label>
+          <input
+            id="mobileNumber"
+            name="mobileNumber"
+            type="tel"
+            placeholder="Enter your mobile number"
+            value={formData.mobileNumber}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="form-control">
+          <label htmlFor="password">Password</label>
+          <div className="password-field">
+            <input
+              id="password"
+              name="password"
+              type={showPassword ? 'text' : 'password'}
+              placeholder="Create a password"
+              value={formData.password}
+              onChange={handleChange}
+              required
+            />
+            <button
+              type="button"
+              className="password-toggle"
+              onClick={() => setShowPassword((prev) => !prev)}
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              {showPassword ? <FiEyeOff /> : <FiEye />}
+            </button>
+          </div>
+        </div>
+
+        <div className="form-control">
+          <label htmlFor="confirmPassword">Confirm Password</label>
+          <div className="password-field">
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type={showConfirmPassword ? 'text' : 'password'}
+              placeholder="Confirm your password"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              required
+            />
+            <button
+              type="button"
+              className="password-toggle"
+              onClick={() => setShowConfirmPassword((prev) => !prev)}
+              aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+            >
+              {showConfirmPassword ? <FiEyeOff /> : <FiEye />}
+            </button>
+          </div>
+        </div>
+
+        {status.message && (
+          <p className={`status-message ${status.type}`}>{status.message}</p>
+        )}
+
+        <button type="submit" className="primary-button" disabled={loading}>
+          {loading ? 'Creating Account…' : 'Sign Up'}
+        </button>
+      </form>
+    </AuthLayout>
+  );
+};
+
+export default SignupPage;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- implement an Express + MySQL backend with JWT-protected signup, login, profile, and reset-password routes
- build a responsive Vite + React frontend featuring modern login and signup experiences with password toggles and responsive layout
- document environment setup steps for running the full stack locally

## Testing
- `npm install` *(fails: registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dbb048f5cc8326aa04d65108aecb9b