### PR TITLE
style: apply brand color to auth checkbox

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -154,6 +154,17 @@ a:hover {
 .checkbox input {
   width: 16px;
   height: 16px;
+  accent-color: #7367f0;
+  border-radius: 4px;
+  border: 1.5px solid #c7c5f5;
+  background-color: #ffffff;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.checkbox input:focus-visible {
+  outline: none;
+  border-color: #7367f0;
+  box-shadow: 0 0 0 3px rgba(115, 103, 240, 0.2);
 }
 
 .primary-button {


### PR DESCRIPTION
## Summary
- update the authentication form checkbox to use the purple brand palette
- add focus-visible styling to keep the control accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbc9983a7883269848edee8de6209d