### PR TITLE
Refactor auth layout logos for responsive display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -28,6 +28,14 @@ a:hover {
   display: grid;
   grid-template-columns: 3fr 2fr;
   min-height: 100vh;
+  position: relative;
+}
+
+.auth-brand-logo {
+  position: absolute;
+  top: 2.5rem;
+  left: 2.5rem;
+  z-index: 2;
 }
 
 .auth-illustration {
@@ -61,9 +69,14 @@ a:hover {
   gap: 1.5rem;
 }
 
-.auth-logo img {
+.auth-brand-logo img,
+.auth-form-logo img {
   width: 48px;
   height: 48px;
+}
+
+.auth-form-logo {
+  display: none;
 }
 
 .auth-header h1 {
@@ -205,6 +218,15 @@ a:hover {
     grid-template-columns: 1fr;
   }
 
+  .auth-brand-logo {
+    display: none;
+  }
+
+  .auth-form-logo {
+    display: block;
+    align-self: flex-start;
+  }
+
   .auth-illustration {
     min-height: 240px;
   }
@@ -221,6 +243,10 @@ a:hover {
 @media (max-width: 640px) {
   body {
     background: #ffffff;
+  }
+
+  .auth-form-logo {
+    margin-bottom: 0.5rem;
   }
 
   .auth-illustration {

--- a/frontend/src/components/AuthLayout.jsx
+++ b/frontend/src/components/AuthLayout.jsx
@@ -6,12 +6,17 @@ import demoImage from '../assets/demo-image.svg';
 const AuthLayout = ({ title, subtitle, children, footer }) => {
   return (
     <div className="auth-container">
+      <div className="auth-brand-logo">
+        <Link to="/">
+          <img src={logo} alt="Demo logo" />
+        </Link>
+      </div>
       <div className="auth-illustration">
         <img src={demoImage} alt="Demo" />
       </div>
       <div className="auth-form">
         <div className="auth-card">
-          <div className="auth-logo">
+          <div className="auth-form-logo">
             <Link to="/">
               <img src={logo} alt="Demo logo" />
             </Link>


### PR DESCRIPTION
## Summary
- move the desktop auth logo outside the card into a dedicated container for better positioning
- add a secondary in-card logo for smaller screens and adjust layout styles
- update responsive styles to toggle the appropriate logo between desktop and mobile breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbc0eaa18c83269d463feda593bb01