### PR TITLE
Ensure MySQL pool uses environment configuration

### DIFF
--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import mysql from 'mysql2/promise';
 
 const createPool = () => {


### PR DESCRIPTION
## Summary
- load dotenv configuration within the MySQL pool module so environment variables are available before initialization

## Testing
- not run (environment not configured for database access)


------
https://chatgpt.com/codex/tasks/task_b_68dbb59a50f08326a83c56b1637eef13