### PR TITLE
Fix mobile auth media query syntax

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -262,13 +262,12 @@ a:hover {
     background: #ffffff;
   }
 
-
   .auth-container {
     grid-template-areas: 'form';
+  }
 
   .auth-form-logo {
     margin-bottom: 0.5rem;
-
   }
 
   .auth-illustration {


### PR DESCRIPTION
## Summary
- close the auth container and logo rule blocks in the mobile media query so the stylesheet parses correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcdc94b67883269603557a4b1a3964