### PR TITLE
Serve frontend build through Express

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,8 +1,14 @@
 import cors from 'cors';
 import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import authRoutes from './routes/authRoutes.js';
 
 const app = express();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const frontendDistPath = path.resolve(__dirname, '../../frontend/dist');
 
 app.use(cors({
   origin: process.env.CLIENT_URL || 'http://localhost:5173',
@@ -10,11 +16,17 @@ app.use(cors({
 }));
 app.use(express.json());
 
+app.use(express.static(frontendDistPath));
+
 app.get('/', (req, res) => {
   res.json({ status: 'OK', message: 'PWA Auth API' });
 });
 
 app.use('/', authRoutes);
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(frontendDistPath, 'index.html'));
+});
 
 app.use((err, req, res, next) => {
   console.error('Unhandled error:', err);


### PR DESCRIPTION
## Summary
- import path utilities so the API can resolve the built frontend directory
- serve the React build through express.static and fall back to index.html for SPA routes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dcf34729588326bb0737034c607efd