### PR TITLE
Implement neutral password reset request handler

### DIFF
--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,12 +1,17 @@
 import { Router } from 'express';
 import { authenticate } from '../middleware/authMiddleware.js';
-import { login, profile, resetPassword, signup } from '../controllers/authController.js';
+import {
+  login,
+  profile,
+  requestPasswordReset,
+  signup
+} from '../controllers/authController.js';
 
 const router = Router();
 
 router.post('/signup', signup);
 router.post('/login', login);
 router.get('/profile', authenticate, profile);
-router.post('/reset-password', resetPassword);
+router.post('/reset-password-request', requestPasswordReset);
 
 export default router;


### PR DESCRIPTION
## Summary
- replace the reset password controller with a neutral requestPasswordReset handler that avoids user enumeration
- guard database and email operations with async/await and try/catch while keeping success responses consistent
- expose the handler via a new /reset-password-request route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dcded65b0c8326a40bbb4af3eb5ac9