### PR TITLE
Add password reset request form with guarded response handling

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,12 +1,14 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import LoginPage from './pages/Login.jsx';
 import SignupPage from './pages/Signup.jsx';
+import ResetPasswordPage from './pages/ResetPassword.jsx';
 
 const App = () => {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignupPage />} />
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
       <Route path="*" element={<Navigate to="/login" replace />} />
     </Routes>
   );

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import AuthLayout from '../components/AuthLayout.jsx';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+
+const ResetPasswordPage = () => {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState({ type: null, message: '' });
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    setLoading(true);
+    setStatus({ type: null, message: '' });
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/reset-password-request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+
+      const contentType = response.headers.get('content-type') || '';
+      let data = null;
+
+      if (contentType.includes('application/json')) {
+        data = await response.json();
+      } else if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || 'Unexpected response from the server.');
+      }
+
+      if (!response.ok) {
+        throw new Error(data?.message || 'Unable to process password reset request.');
+      }
+
+      setStatus({
+        type: 'success',
+        message:
+          data?.message ||
+          'If an account matches that email, a reset link has been sent.'
+      });
+      setEmail('');
+    } catch (error) {
+      setStatus({
+        type: 'error',
+        message: error.message || 'An unexpected error occurred. Please try again.'
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AuthLayout
+      title="Forgot Password"
+      subtitle="Enter your email to receive a reset link"
+      footer={
+        <p>
+          Remembered your password? <Link to="/login">Return to login</Link>
+        </p>
+      }
+    >
+      <form className="auth-form-body" onSubmit={handleSubmit}>
+        <div className="form-control">
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="Enter your email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+
+        {status.message && (
+          <p className={`status-message ${status.type}`}>{status.message}</p>
+        )}
+
+        <button type="submit" className="primary-button" disabled={loading}>
+          {loading ? 'Sending…' : 'Send Reset Link'}
+        </button>
+      </form>
+    </AuthLayout>
+  );
+};
+
+export default ResetPasswordPage;


### PR DESCRIPTION
## Summary
- add a password reset page that posts reset requests to the backend endpoint
- guard response parsing so JSON is only read when returned and surface clear errors otherwise
- register the reset password route in the app router

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd120b54c0832681166353b4668d20