### PR TITLE
Use relative API fallback for auth pages

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -3,7 +3,7 @@ import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { Link } from 'react-router-dom';
 import AuthLayout from '../components/AuthLayout.jsx';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const LoginPage = () => {
   const [formData, setFormData] = useState({

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import AuthLayout from '../components/AuthLayout.jsx';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const ResetPasswordPage = () => {
   const [email, setEmail] = useState('');

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -3,7 +3,7 @@ import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { Link, useNavigate } from 'react-router-dom';
 import AuthLayout from '../components/AuthLayout.jsx';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const SignupPage = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- update the login, signup, and reset password pages to default API_BASE_URL to a relative /api path when an env override is not provided
- confirmed that endpoint construction still builds correctly with both the relative fallback and an explicit VITE_API_BASE_URL during builds

## Testing
- npm run build
- VITE_API_BASE_URL=https://api.example.com npm run build

------
https://chatgpt.com/codex/tasks/task_b_68df95a648188326917fed029064a050