### PR TITLE
Fix admin base URL resolution for admin pages

### DIFF
--- a/frontend/src/pages/AdminCreateUserAccount.jsx
+++ b/frontend/src/pages/AdminCreateUserAccount.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import resolveAdminBaseUrl from '../utils/resolveAdminBaseUrl.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 const PAGE_OPTIONS = [
@@ -25,10 +26,7 @@ const AdminCreateUserAccountPage = () => {
       return null;
     }
   }, []);
-  const adminBaseUrl = useMemo(() => {
-    const normalized = API_BASE_URL.replace(/\/?api\/?$/, '');
-    return normalized === API_BASE_URL ? '' : normalized;
-  }, []);
+  const adminBaseUrl = useMemo(() => resolveAdminBaseUrl(API_BASE_URL), []);
   const [searchQuery, setSearchQuery] = useState('');
   const [searching, setSearching] = useState(false);
   const [searchResults, setSearchResults] = useState([]);

--- a/frontend/src/pages/AdminLogin.jsx
+++ b/frontend/src/pages/AdminLogin.jsx
@@ -2,15 +2,13 @@ import { useMemo, useState } from 'react';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { Link, useNavigate } from 'react-router-dom';
 import AuthLayout from '../components/AuthLayout.jsx';
+import resolveAdminBaseUrl from '../utils/resolveAdminBaseUrl.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const AdminLoginPage = () => {
   const navigate = useNavigate();
-  const adminBaseUrl = useMemo(() => {
-    const normalized = API_BASE_URL.replace(/\/?api\/?$/, '');
-    return normalized === API_BASE_URL ? '' : normalized;
-  }, []);
+  const adminBaseUrl = useMemo(() => resolveAdminBaseUrl(API_BASE_URL), []);
   const [formData, setFormData] = useState({
     adminName: '',
     email: '',

--- a/frontend/src/pages/AdminSignup.jsx
+++ b/frontend/src/pages/AdminSignup.jsx
@@ -2,15 +2,13 @@ import { useMemo, useState } from 'react';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
 import { Link, useNavigate } from 'react-router-dom';
 import AuthLayout from '../components/AuthLayout.jsx';
+import resolveAdminBaseUrl from '../utils/resolveAdminBaseUrl.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
 const AdminSignupPage = () => {
   const navigate = useNavigate();
-  const adminBaseUrl = useMemo(() => {
-    const normalized = API_BASE_URL.replace(/\/?api\/?$/, '');
-    return normalized === API_BASE_URL ? '' : normalized;
-  }, []);
+  const adminBaseUrl = useMemo(() => resolveAdminBaseUrl(API_BASE_URL), []);
   const [formData, setFormData] = useState({
     adminName: '',
     email: '',

--- a/frontend/src/utils/resolveAdminBaseUrl.js
+++ b/frontend/src/utils/resolveAdminBaseUrl.js
@@ -1,0 +1,29 @@
+const normalizeBaseUrl = (baseUrl) => {
+  if (!baseUrl) {
+    return '';
+  }
+
+  const trimmed = baseUrl.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  const withoutTrailingSlash = trimmed.replace(/\/+$/, '');
+
+  if (/(^|\/)api$/i.test(withoutTrailingSlash)) {
+    const shortened = withoutTrailingSlash.slice(0, -3);
+
+    if (shortened.endsWith('/')) {
+      return shortened.slice(0, -1);
+    }
+
+    return shortened;
+  }
+
+  return withoutTrailingSlash;
+};
+
+export const resolveAdminBaseUrl = (baseUrl) => normalizeBaseUrl(baseUrl);
+
+export default resolveAdminBaseUrl;


### PR DESCRIPTION
## Summary
- ensure admin admin pages reuse a shared resolver so absolute API bases are respected
- add a utility to normalize admin base URLs when trimming optional /api suffixes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e6335d2c248329af8c20a9fc67f751