### PR TITLE
Adjust tablet sidebar width for dashboard menu

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -852,7 +852,8 @@ a:hover {
   position: fixed;
   inset: 0 auto 0 0;
   transform: translateX(-100%);
-  width: 100vw;
+  width: min(360px, 100vw);
+  max-width: 100%;
   min-height: 100vh;
   height: 100%;
   padding: clamp(2.5rem, 8vw, 3.25rem) clamp(1.75rem, 6vw, 2.5rem);


### PR DESCRIPTION
## Summary
- limit the dashboard sidebar width on mobile layouts so opening the menu no longer covers the entire viewport on tablet-sized screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e79306276c8329bf007d9dbe13e5f7