### PR TITLE
Fix case-insensitive dashboard link retrieval

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -220,16 +220,17 @@ export const searchUsers = async (req, res) => {
       );
 
       linksByEmail = links.reduce((accumulator, row) => {
-        const list = accumulator.get(row.email) || [];
+        const key = row.email?.toLowerCase() || row.email;
+        const list = accumulator.get(key) || [];
         list.push({ page: row.page, link: row.link, createdAt: row.createdAt });
-        accumulator.set(row.email, list);
+        accumulator.set(key, list);
         return accumulator;
       }, new Map());
     }
 
     const results = users.map((user) => ({
       ...user,
-      links: linksByEmail.get(user.email) || []
+      links: linksByEmail.get(user.email?.toLowerCase()) || []
     }));
 
     userSearchCache.set(normalizedQuery, results);


### PR DESCRIPTION
## Summary
- normalize dashboard link lookup keys to avoid mismatches caused by email casing
- return dashboard links for users regardless of how their email casing is stored

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e7b68234148329bb393ffab44f7858