### PR TITLE
Fix service worker caching to avoid stale assets

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,10 +1,45 @@
-const CACHE_NAME = 'pwa-auth-cache-v1';
-const APP_SHELL = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/icons/icon.svg'
-];
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `pwa-auth-cache-${CACHE_VERSION}`;
+const APP_SHELL = ['/', '/index.html', '/manifest.json', '/icons/icon.svg'];
+
+const addToCache = async (request, response) => {
+  if (response && response.ok) {
+    const cache = await caches.open(CACHE_NAME);
+    cache.put(request, response);
+  }
+};
+
+const cacheFirst = async (request) => {
+  const cachedResponse = await caches.match(request);
+
+  if (cachedResponse) {
+    return cachedResponse;
+  }
+
+  const networkResponse = await fetch(request);
+  addToCache(request, networkResponse.clone());
+
+  return networkResponse;
+};
+
+const networkFirst = async (request) => {
+  try {
+    const networkResponse = await fetch(request);
+    addToCache(request, networkResponse.clone());
+    return networkResponse;
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    if (request.mode === 'navigate') {
+      return caches.match('/index.html');
+    }
+
+    throw error;
+  }
+};
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
@@ -20,42 +55,42 @@ self.addEventListener('activate', (event) => {
     caches
       .keys()
       .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => key !== CACHE_NAME)
-            .map((key) => caches.delete(key))
-        )
+        Promise.all(keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : null)))
       )
       .then(() => self.clients.claim())
   );
 });
 
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
 self.addEventListener('fetch', (event) => {
-  if (event.request.method !== 'GET') {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
     return;
   }
 
-  event.respondWith(
-    caches.match(event.request).then((cachedResponse) => {
-      if (cachedResponse) {
-        return cachedResponse;
-      }
+  const isSameOrigin = request.url.startsWith(self.location.origin);
 
-      return caches.open(CACHE_NAME).then((cache) =>
-        fetch(event.request)
-          .then((response) => {
-            if (
-              response &&
-              response.status === 200 &&
-              response.type === 'basic'
-            ) {
-              cache.put(event.request, response.clone());
-            }
+  if (!isSameOrigin) {
+    return;
+  }
 
-            return response;
-          })
-          .catch(() => cachedResponse)
-      );
-    })
-  );
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  const assetTypes = ['style', 'script', 'worker', 'font'];
+
+  if (assetTypes.includes(request.destination)) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  event.respondWith(networkFirst(request));
 });

--- a/frontend/src/pwa/registerServiceWorker.js
+++ b/frontend/src/pwa/registerServiceWorker.js
@@ -6,6 +6,29 @@ export const registerServiceWorker = () => {
   const register = () => {
     navigator.serviceWorker
       .register('/sw.js')
+      .then((registration) => {
+        if (registration.waiting) {
+          registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing;
+
+          if (!newWorker) {
+            return;
+          }
+
+          newWorker.addEventListener('statechange', () => {
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+              newWorker.postMessage({ type: 'SKIP_WAITING' });
+            }
+          });
+        });
+
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          window.location.reload();
+        });
+      })
       .catch((error) => {
         console.error('Service worker registration failed:', error);
       });


### PR DESCRIPTION
## Summary
- replace the cache-all strategy with navigation-first and asset-aware caching paths to avoid stale CSS and blank screens
- notify waiting service workers to activate immediately and reload the page on controller changes for consistent updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e89e461dc0832988a34446b1492731