### PR TITLE
Add pricing landing page and refresh branding

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -52,6 +52,53 @@ a:hover {
   text-decoration: underline;
 }
 
+.brand-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+  color: #25293c;
+  text-decoration: none;
+}
+
+.brand-logo:hover,
+.brand-logo:focus-visible {
+  color: #25293c;
+  text-decoration: none;
+}
+
+.brand-logo-mark {
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brand-logo-mark img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+.brand-logo-text {
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  color: currentColor;
+}
+
+.brand-logo-vertical {
+  flex-direction: column;
+  text-align: center;
+  gap: 0.75rem;
+}
+
+.brand-logo-vertical .brand-logo-text {
+  font-size: 1.35rem;
+}
+
 .auth-container {
   display: grid;
   grid-template-columns: 3fr 2fr;
@@ -100,8 +147,25 @@ a:hover {
   gap: 1.5rem;
 }
 
-.auth-brand-logo img,
-.auth-form-logo img {
+.auth-brand-logo .brand-logo,
+.auth-form-logo .brand-logo {
+  gap: 0.65rem;
+}
+
+.auth-brand-logo .brand-logo {
+  color: #ffffff;
+}
+
+.auth-brand-logo .brand-logo-text {
+  color: #ffffff;
+}
+
+.auth-form-logo .brand-logo {
+  color: #25293c;
+}
+
+.auth-brand-logo .brand-logo-mark,
+.auth-form-logo .brand-logo-mark {
   width: 48px;
   height: 48px;
 }
@@ -641,9 +705,25 @@ a:hover {
 }
 
 .sidebar-logo {
-  width: 48px;
-  height: auto;
-  transition: all 0.3s ease-in-out;
+  color: #ffffff;
+  gap: 0.75rem;
+  font-size: 1.05rem;
+  transition: color 0.3s ease-in-out;
+}
+
+.sidebar-logo:hover,
+.sidebar-logo:focus-visible {
+  color: #ffffff;
+}
+
+.sidebar-logo .brand-logo-text {
+  color: inherit;
+  font-size: 1.15rem;
+}
+
+.sidebar-logo .brand-logo-mark {
+  width: 42px;
+  height: 42px;
 }
 
 .sidebar-toggle {
@@ -824,9 +904,19 @@ a:hover {
   color: #ffffff;
 }
 
-.mobile-header-logo img {
-  width: 44px;
-  height: auto;
+.mobile-header-logo .brand-logo {
+  color: #ffffff;
+  gap: 0.65rem;
+}
+
+.mobile-header-logo .brand-logo-text {
+  color: #ffffff;
+  font-size: 1.05rem;
+}
+
+.mobile-header-logo .brand-logo-mark {
+  width: 40px;
+  height: 40px;
 }
 
 .mobile-menu-toggle {
@@ -980,6 +1070,450 @@ a:hover {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* Pricing page styles */
+.pricing-page {
+  min-height: 100vh;
+  background: #f6f6fe;
+  color: #25293c;
+}
+
+.pricing-navbar {
+  position: sticky;
+  top: 0;
+  z-index: 105;
+  width: 100%;
+  padding: 1.25rem 2.5rem;
+  background: #f6f6fe;
+  transition: all 0.4s ease;
+}
+
+.pricing-navbar-scrolled {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  border-radius: 50px;
+  margin: 1rem auto;
+  max-width: min(1100px, 92%);
+  padding: 0.85rem 2rem;
+  top: 1rem;
+}
+
+.pricing-navbar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  transition: gap 0.3s ease;
+}
+
+.pricing-logo .brand-logo-mark {
+  width: 44px;
+  height: 44px;
+}
+
+.pricing-logo .brand-logo-text {
+  font-size: 1.3rem;
+}
+
+.pricing-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+}
+
+.pricing-nav-link {
+  position: relative;
+  font-weight: 500;
+  color: #25293c;
+  padding-bottom: 0.35rem;
+  transition: color 0.3s ease;
+}
+
+.pricing-nav-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -0.1rem;
+  width: 0;
+  height: 2px;
+  background: #25293c;
+  transition: width 0.3s ease;
+}
+
+.pricing-nav-link:hover::after,
+.pricing-nav-link:focus-visible::after,
+.pricing-nav-link.active::after {
+  width: 100%;
+}
+
+.pricing-nav-link.active {
+  font-weight: 600;
+}
+
+.pricing-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.pricing-login {
+  color: #25293c;
+  font-weight: 500;
+}
+
+.pricing-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 25px;
+  background: #25293c;
+  color: #ffffff;
+  font-weight: 600;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.pricing-cta:hover,
+.pricing-cta:focus-visible {
+  background: #3b3f58;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.pricing-menu-toggle {
+  display: none;
+  background: rgba(37, 41, 60, 0.08);
+  border: none;
+  color: #25293c;
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.pricing-menu-toggle:hover,
+.pricing-menu-toggle:focus-visible {
+  background: rgba(37, 41, 60, 0.16);
+  transform: translateY(-2px);
+}
+
+.pricing-mobile-menu {
+  display: none;
+}
+
+.pricing-main {
+  padding: 4.5rem 2.5rem 4rem;
+}
+
+.pricing-hero {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: center;
+  gap: 3rem;
+  min-height: 80vh;
+}
+
+.pricing-hero-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.pricing-hero-copy .eyebrow {
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.28rem;
+  font-weight: 600;
+  color: rgba(37, 41, 60, 0.65);
+  margin: 0;
+}
+
+.pricing-hero-copy h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw + 1rem, 3rem);
+  line-height: 1.1;
+  color: #25293c;
+  font-weight: 700;
+}
+
+.pricing-hero-copy .description {
+  margin: 0;
+  font-size: 1.125rem;
+  color: rgba(0, 0, 0, 0.8);
+  max-width: 420px;
+}
+
+.pricing-frequency {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #dcdcf7;
+  border-radius: 999px;
+  padding: 0.5rem;
+  gap: 0.5rem;
+  width: min(420px, 100%);
+  padding-bottom: 1.75rem;
+  box-shadow: 0 18px 40px rgba(114, 103, 240, 0.08);
+}
+
+.billing-option {
+  position: relative;
+  border: none;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #25293c;
+  font-weight: 600;
+  padding: 0.85rem 1.25rem;
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.billing-option:hover,
+.billing-option:focus-visible {
+  box-shadow: inset 0 0 0 1px rgba(37, 41, 60, 0.12);
+}
+
+.billing-option.active {
+  background: #25293c;
+  color: #ffffff;
+  box-shadow: 0 12px 32px rgba(37, 41, 60, 0.3);
+}
+
+.billing-option .billing-note {
+  position: absolute;
+  bottom: -1.6rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.875rem;
+  font-style: italic;
+  color: #25293c;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.pricing-hero-visual {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 360px;
+}
+
+.pricing-ribbons {
+  position: relative;
+  width: min(440px, 100%);
+  aspect-ratio: 1;
+  filter: drop-shadow(0 35px 55px rgba(37, 41, 60, 0.18));
+}
+
+.pricing-ribbons::before,
+.pricing-ribbons::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 52% 48% 56% 44% / 45% 55% 45% 55%;
+  opacity: 0.2;
+}
+
+.pricing-ribbons::before {
+  background: linear-gradient(135deg, rgba(0, 132, 255, 0.9), rgba(216, 79, 250, 0.85));
+  animation: pricingFloat 8s ease-in-out infinite alternate;
+}
+
+.pricing-ribbons::after {
+  inset: 12%;
+  background: linear-gradient(135deg, rgba(37, 41, 60, 0.95), rgba(255, 0, 180, 0.8));
+  opacity: 0.24;
+  animation: pricingFloatReverse 9s ease-in-out infinite alternate;
+}
+
+@keyframes pricingFloat {
+  0% {
+    transform: rotate(12deg) translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: rotate(4deg) translate3d(0, -18px, 0);
+  }
+}
+
+@keyframes pricingFloatReverse {
+  0% {
+    transform: rotate(-14deg) translate3d(0, 0, 0);
+  }
+
+  100% {
+    transform: rotate(-4deg) translate3d(0, 18px, 0);
+  }
+}
+
+@media (max-width: 1200px) {
+  .pricing-navbar-inner {
+    gap: 1.5rem;
+  }
+
+  .pricing-nav {
+    gap: 1.4rem;
+  }
+}
+
+@media (max-width: 1023px) {
+  .pricing-navbar {
+    padding: 1.15rem 2rem;
+  }
+
+  .pricing-navbar-scrolled {
+    padding: 0.75rem 1.75rem;
+  }
+
+  .pricing-main {
+    padding: 4rem 1.75rem 3.5rem;
+  }
+
+  .pricing-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+    gap: 2.75rem;
+  }
+
+  .pricing-hero-copy {
+    align-items: center;
+  }
+
+  .pricing-hero-copy .description {
+    max-width: 520px;
+  }
+
+  .pricing-frequency {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (max-width: 767px) {
+  .pricing-navbar {
+    padding: 1rem 1.35rem;
+  }
+
+  .pricing-navbar-scrolled {
+    max-width: min(640px, 94%);
+    padding: 0.7rem 1.25rem;
+  }
+
+  .pricing-nav,
+  .pricing-actions {
+    display: none;
+  }
+
+  .pricing-menu-toggle {
+    display: inline-flex;
+  }
+
+  .pricing-mobile-menu {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    position: fixed;
+    inset: 0;
+    padding: 6rem 1.5rem 2rem;
+    background: rgba(246, 246, 254, 0.96);
+    backdrop-filter: blur(12px);
+    transform: translateY(-10%);
+    opacity: 0;
+    pointer-events: none;
+    transition: all 0.3s ease;
+    z-index: 104;
+  }
+
+  .pricing-mobile-menu.open {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .pricing-mobile-nav {
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  .pricing-mobile-link {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #25293c;
+  }
+
+  .pricing-mobile-link.active {
+    text-decoration: underline;
+  }
+
+  .pricing-mobile-actions {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .pricing-main {
+    padding: 3.25rem 1.25rem 3.25rem;
+  }
+
+  .pricing-hero {
+    min-height: calc(100vh - 120px);
+  }
+
+  .pricing-hero-copy h1 {
+    font-size: clamp(2rem, 8vw, 2.6rem);
+  }
+
+  .pricing-frequency {
+    width: 100%;
+  }
+}
+
+@media (max-width: 540px) {
+  .pricing-navbar {
+    padding: 0.9rem 1.1rem;
+  }
+
+  .pricing-navbar-scrolled {
+    padding: 0.65rem 1rem;
+  }
+
+  .pricing-hero-copy .description {
+    font-size: 1.05rem;
+  }
+
+  .pricing-ribbons {
+    max-width: 320px;
+  }
+
+  .billing-option {
+    font-size: 0.95rem;
+    padding-inline: 1rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .pricing-navbar-scrolled {
+    margin: 0.75rem auto;
+  }
+
+  .pricing-hero-copy {
+    gap: 1rem;
+  }
+
+  .pricing-hero-copy h1 {
+    font-size: clamp(1.95rem, 9vw, 2.35rem);
+  }
+
+  .billing-option .billing-note {
+    bottom: -1.8rem;
   }
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ const ResetPasswordPage = lazy(() => import('./pages/ResetPassword.jsx'));
 const AdminLoginPage = lazy(() => import('./pages/AdminLogin.jsx'));
 const AdminSignupPage = lazy(() => import('./pages/AdminSignup.jsx'));
 const AdminCreateUserAccountPage = lazy(() => import('./pages/AdminCreateUserAccount.jsx'));
+const PricingPage = lazy(() => import('./pages/Pricing.jsx'));
 
 const App = () => {
   return (
@@ -22,6 +23,7 @@ const App = () => {
       <Routes>
         <Route path="/" element={<Navigate to="/login" replace />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/pricing" element={<PricingPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route path="/admin/login" element={<AdminLoginPage />} />
         <Route path="/admin/signup" element={<AdminSignupPage />} />

--- a/frontend/src/components/AuthLayout.jsx
+++ b/frontend/src/components/AuthLayout.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import logo from '../assets/logo.svg';
+import BrandLogo from './BrandLogo.jsx';
 import loginImage from '../assets/login-image.svg';
 
 const AuthLayout = ({
@@ -13,9 +12,7 @@ const AuthLayout = ({
   return (
     <div className="auth-container">
       <div className="auth-brand-logo">
-        <Link to="/">
-          <img src={logo} alt="Demo logo" />
-        </Link>
+        <BrandLogo to="/pricing" ariaLabel="Dashvio home" />
       </div>
       <div className="auth-illustration">
         <img src={illustrationSrc} alt="Authentication illustration" />
@@ -23,9 +20,7 @@ const AuthLayout = ({
       <div className="auth-form">
         <div className="auth-card">
           <div className="auth-form-logo">
-            <Link to="/">
-              <img src={logo} alt="Demo logo" />
-            </Link>
+            <BrandLogo to="/pricing" ariaLabel="Dashvio home" />
           </div>
           <div className="auth-header">
             <h1>{title}</h1>

--- a/frontend/src/components/BrandLogo.jsx
+++ b/frontend/src/components/BrandLogo.jsx
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import logo from '../assets/logo.svg';
+
+const BrandLogo = ({ to, className, orientation, showText, ariaLabel, onClick }) => {
+  const classes = ['brand-logo'];
+
+  if (orientation === 'vertical') {
+    classes.push('brand-logo-vertical');
+  } else {
+    classes.push('brand-logo-horizontal');
+  }
+
+  if (className) {
+    classes.push(className);
+  }
+
+  const content = (
+    <>
+      <span className="brand-logo-mark" aria-hidden="true">
+        <img src={logo} alt="" loading="lazy" />
+      </span>
+      {showText && <span className="brand-logo-text">Dashvio</span>}
+    </>
+  );
+
+  if (to) {
+    return (
+      <Link to={to} className={classes.join(' ')} aria-label={ariaLabel} onClick={onClick}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <div className={classes.join(' ')} aria-label={ariaLabel} onClick={onClick}>
+      {content}
+    </div>
+  );
+};
+
+BrandLogo.propTypes = {
+  to: PropTypes.string,
+  className: PropTypes.string,
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  showText: PropTypes.bool,
+  ariaLabel: PropTypes.string,
+  onClick: PropTypes.func
+};
+
+BrandLogo.defaultProps = {
+  to: undefined,
+  className: '',
+  orientation: 'horizontal',
+  showText: true,
+  ariaLabel: 'Dashvio',
+  onClick: undefined
+};
+
+export default BrandLogo;

--- a/frontend/src/components/DashboardLayout.jsx
+++ b/frontend/src/components/DashboardLayout.jsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FiLogOut, FiMenu, FiSidebar, FiX } from 'react-icons/fi';
 import { LuIndianRupee, LuLayoutDashboard, LuTrendingUp } from 'react-icons/lu';
 import { NavLink, Outlet, useNavigate } from 'react-router-dom';
-import logo from '../assets/logo.svg';
+import BrandLogo from './BrandLogo.jsx';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
 
@@ -56,8 +56,8 @@ const Sidebar = memo(
       <aside className={sidebarClassName}>
         <div className="sidebar-top">
           {(!collapsed || isMobile) && (
-            <div className="sidebar-brand" aria-label="Application logo">
-              <img src={logo} alt="App logo" className="sidebar-logo" loading="lazy" />
+            <div className="sidebar-brand" aria-label="Dashvio">
+              <BrandLogo className="sidebar-logo" to="/pricing" ariaLabel="Dashvio" />
             </div>
           )}
 
@@ -338,8 +338,8 @@ const DashboardLayout = () => {
     <div className={shellClassName}>
       {isMobileViewport && (
         <header className="dashboard-mobile-header">
-          <div className="mobile-header-logo" aria-label="Application logo">
-            <img src={logo} alt="App logo" loading="lazy" />
+          <div className="mobile-header-logo" aria-label="Dashvio">
+            <BrandLogo className="sidebar-logo" to="/pricing" ariaLabel="Dashvio" />
           </div>
 
           <button

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from 'react';
+import { FiMenu, FiX } from 'react-icons/fi';
+import BrandLogo from '../components/BrandLogo.jsx';
+
+const BILLING_OPTIONS = ['MONTHLY', 'QUARTERLY', 'YEARLY'];
+
+const navLinks = [
+  { label: 'Home', href: '/login' },
+  { label: 'Solutions', href: '#' },
+  { label: 'Contact', href: '#' },
+  { label: 'Pricing', href: '/pricing' }
+];
+
+const Pricing = () => {
+  const [billingCycle, setBillingCycle] = useState('YEARLY');
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 10);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const { body } = document;
+
+    if (isMenuOpen) {
+      body.style.setProperty('overflow', 'hidden');
+    } else {
+      body.style.removeProperty('overflow');
+    }
+
+    return () => {
+      body.style.removeProperty('overflow');
+    };
+  }, [isMenuOpen]);
+
+  const navigationItems = useMemo(
+    () =>
+      navLinks.map((link) => ({
+        ...link,
+        isActive: link.href === '/pricing'
+      })),
+    []
+  );
+
+  const closeMenu = () => setIsMenuOpen(false);
+
+  const handleOptionClick = (option) => {
+    setBillingCycle(option);
+  };
+
+  return (
+    <div className="pricing-page">
+      <header className={`pricing-navbar ${isScrolled ? 'pricing-navbar-scrolled' : ''}`}>
+        <div className="pricing-navbar-inner">
+          <BrandLogo to="/pricing" className="pricing-logo" ariaLabel="Dashvio" />
+          <nav className="pricing-nav" aria-label="Primary">
+            {navigationItems.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                className={`pricing-nav-link ${link.isActive ? 'active' : ''}`}
+                aria-current={link.isActive ? 'page' : undefined}
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+          <div className="pricing-actions">
+            <a href="/login" className="pricing-login">Login</a>
+            <a href="#contact-sales" className="pricing-cta">Contact Sales</a>
+          </div>
+          <button
+            type="button"
+            className="pricing-menu-toggle"
+            onClick={() => setIsMenuOpen((prev) => !prev)}
+            aria-label={isMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={isMenuOpen}
+          >
+            {isMenuOpen ? <FiX aria-hidden="true" /> : <FiMenu aria-hidden="true" />}
+          </button>
+        </div>
+        <div className={`pricing-mobile-menu ${isMenuOpen ? 'open' : ''}`}>
+          <nav className="pricing-mobile-nav" aria-label="Mobile navigation">
+            {navigationItems.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                className={`pricing-mobile-link ${link.isActive ? 'active' : ''}`}
+                aria-current={link.isActive ? 'page' : undefined}
+                onClick={closeMenu}
+              >
+                {link.label}
+              </a>
+            ))}
+          </nav>
+          <div className="pricing-mobile-actions">
+            <a href="/login" className="pricing-login" onClick={closeMenu}>
+              Login
+            </a>
+            <a href="#contact-sales" className="pricing-cta" onClick={closeMenu}>
+              Contact Sales
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="pricing-main">
+        <section className="pricing-hero">
+          <div className="pricing-hero-copy">
+            <p className="eyebrow">Pricing</p>
+            <h1>Find the right plan</h1>
+            <p className="description">Pay for dashboards, not data sources.</p>
+            <div className="pricing-frequency">
+              {BILLING_OPTIONS.map((option) => (
+                <button
+                  type="button"
+                  key={option}
+                  className={`billing-option ${billingCycle === option ? 'active' : ''}`}
+                  onClick={() => handleOptionClick(option)}
+                  aria-pressed={billingCycle === option}
+                >
+                  {option}
+                  {option === 'YEARLY' && (
+                    <span className="billing-note" aria-hidden="true">
+                      Best Value!
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="pricing-hero-visual" aria-hidden="true">
+            <div className="pricing-ribbons" />
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Pricing;


### PR DESCRIPTION
## Summary
- add a `/pricing` marketing page with a sticky hero layout, responsive navbar, and interactive billing toggle
- extract a reusable `BrandLogo` component and replace legacy logo usages in auth and dashboard surfaces
- extend global styling to support the Dashvio brand and new pricing visuals across breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e8b4b0271c8329b54361c9cbf96b27