### PR TITLE
Improve pricing CTA and mobile navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -938,6 +938,121 @@ a:hover {
 }
 
 
+.dashboard-mobile-menu {
+  display: none;
+}
+
+.dashboard-shell.mobile .dashboard-mobile-menu {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 5.5rem 1.75rem 2rem;
+  background: rgba(24, 25, 38, 0.96);
+  backdrop-filter: blur(14px);
+  transform: translateY(-10%);
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.3s ease;
+  z-index: 1100;
+  overflow-y: auto;
+}
+
+.dashboard-shell.mobile .dashboard-mobile-menu.open {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.dashboard-mobile-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.dashboard-mobile-close {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  color: #ffffff;
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.35rem;
+  cursor: pointer;
+  transition: all 0.3s ease-in-out;
+}
+
+.dashboard-mobile-close:hover,
+.dashboard-mobile-close:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-2px);
+}
+
+.dashboard-mobile-nav {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.dashboard-mobile-link {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: transparent;
+  color: #f6f6fe;
+  font-size: 1.2rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.dashboard-mobile-link:hover,
+.dashboard-mobile-link:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
+}
+
+.dashboard-mobile-link.active {
+  background: rgba(114, 102, 237, 0.3);
+  color: #ffffff;
+  box-shadow: 0 18px 38px rgba(8, 8, 22, 0.36);
+}
+
+.dashboard-mobile-icon svg {
+  font-size: 1.35rem;
+}
+
+.dashboard-mobile-logout {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: #ffffff;
+  font-size: 1.15rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.dashboard-mobile-logout:hover,
+.dashboard-mobile-logout:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.dashboard-mobile-label {
+  display: inline-flex;
+}
+
+
 .dashboard-shell.mobile .dashboard-sidebar {
   position: fixed;
   inset: 0 auto 0 0;
@@ -1172,7 +1287,7 @@ a:hover {
   justify-content: center;
   padding: 0.65rem 1.6rem;
   border-radius: 25px;
-  background: #25293c;
+  background: #7266ed;
   color: #ffffff;
   font-weight: 600;
   transition: background 0.3s ease, transform 0.3s ease;
@@ -1259,8 +1374,7 @@ a:hover {
   border-radius: 999px;
   padding: 0.5rem;
   gap: 0.5rem;
-  width: min(420px, 100%);
-  padding-bottom: 1.75rem;
+  width: min(440px, 100%);
   box-shadow: 0 18px 40px rgba(114, 103, 240, 0.08);
 }
 
@@ -1285,18 +1399,6 @@ a:hover {
   background: #25293c;
   color: #ffffff;
   box-shadow: 0 12px 32px rgba(37, 41, 60, 0.3);
-}
-
-.billing-option .billing-note {
-  position: absolute;
-  bottom: -1.6rem;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 0.875rem;
-  font-style: italic;
-  color: #25293c;
-  pointer-events: none;
-  white-space: nowrap;
 }
 
 .pricing-hero-visual {
@@ -1433,6 +1535,29 @@ a:hover {
     z-index: 104;
   }
 
+  .pricing-mobile-menu .pricing-mobile-close {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    border: none;
+    display: grid;
+    place-items: center;
+    background: rgba(37, 41, 60, 0.08);
+    color: #25293c;
+    font-size: 1.3rem;
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.3s ease;
+  }
+
+  .pricing-mobile-menu .pricing-mobile-close:hover,
+  .pricing-mobile-menu .pricing-mobile-close:focus-visible {
+    background: rgba(37, 41, 60, 0.16);
+    transform: translateY(-1px);
+  }
+
   .pricing-mobile-menu.open {
     transform: translateY(0);
     opacity: 1;
@@ -1495,7 +1620,8 @@ a:hover {
 
   .billing-option {
     font-size: 0.95rem;
-    padding-inline: 1rem;
+    padding-inline: 0.85rem;
+    padding-block: 0.75rem;
   }
 }
 
@@ -1510,10 +1636,6 @@ a:hover {
 
   .pricing-hero-copy h1 {
     font-size: clamp(1.95rem, 9vw, 2.35rem);
-  }
-
-  .billing-option .billing-note {
-    bottom: -1.8rem;
   }
 }
 

--- a/frontend/src/components/DashboardLayout.jsx
+++ b/frontend/src/components/DashboardLayout.jsx
@@ -298,6 +298,24 @@ const DashboardLayout = () => {
     updateMobileMenu(false);
   }, [updateMobileMenu]);
 
+  useEffect(() => {
+    if (!isMobileViewport || typeof document === 'undefined') {
+      return undefined;
+    }
+
+    const { body } = document;
+
+    if (isMobileMenuOpen) {
+      body.style.setProperty('overflow', 'hidden');
+    } else {
+      body.style.removeProperty('overflow');
+    }
+
+    return () => {
+      body.style.removeProperty('overflow');
+    };
+  }, [isMobileMenuOpen, isMobileViewport]);
+
   useEffect(
     () => () => {
       if (collapseAnimationRef.current) {
@@ -354,15 +372,64 @@ const DashboardLayout = () => {
         </header>
       )}
 
-      <Sidebar
-        collapsed={collapsedForDesktop}
-        isMobile={isMobileViewport}
-        isMobileMenuOpen={isMobileMenuOpen}
-        navItems={navItems}
-        onToggle={handleToggle}
-        onLogout={handleLogout}
-        onCloseMobileMenu={handleCloseMobileMenu}
-      />
+      {!isMobileViewport && (
+        <Sidebar
+          collapsed={collapsedForDesktop}
+          isMobile={isMobileViewport}
+          isMobileMenuOpen={isMobileMenuOpen}
+          navItems={navItems}
+          onToggle={handleToggle}
+          onLogout={handleLogout}
+          onCloseMobileMenu={handleCloseMobileMenu}
+        />
+      )}
+
+      {isMobileViewport && (
+        <div
+          className={`dashboard-mobile-menu ${isMobileMenuOpen ? 'open' : ''}`}
+          aria-hidden={!isMobileMenuOpen}
+        >
+          <div className="dashboard-mobile-menu-header">
+            <BrandLogo className="sidebar-logo" to="/pricing" ariaLabel="Dashvio" />
+            <button
+              type="button"
+              className="dashboard-mobile-close"
+              onClick={handleCloseMobileMenu}
+              aria-label="Close sidebar menu"
+            >
+              <FiX aria-hidden="true" />
+            </button>
+          </div>
+
+          <nav className="dashboard-mobile-nav" aria-label="Dashboard navigation">
+            {navItems.map((item) => {
+              const Icon = item.icon;
+
+              return (
+                <NavLink
+                  key={item.path}
+                  to={item.path}
+                  end={item.path === '/dashboard'}
+                  className={({ isActive }) => `dashboard-mobile-link ${isActive ? 'active' : ''}`}
+                  onClick={handleCloseMobileMenu}
+                >
+                  <span className="dashboard-mobile-icon" aria-hidden="true">
+                    <Icon />
+                  </span>
+                  <span className="dashboard-mobile-label">{item.label}</span>
+                </NavLink>
+              );
+            })}
+          </nav>
+
+          <button type="button" className="dashboard-mobile-logout" onClick={handleLogout}>
+            <span className="dashboard-mobile-icon" aria-hidden="true">
+              <FiLogOut />
+            </span>
+            <span className="dashboard-mobile-label">Logout</span>
+          </button>
+        </div>
+      )}
 
       {isMobileViewport && (
         <div

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -94,6 +94,14 @@ const Pricing = () => {
           </button>
         </div>
         <div className={`pricing-mobile-menu ${isMenuOpen ? 'open' : ''}`}>
+          <button
+            type="button"
+            className="pricing-mobile-close"
+            onClick={closeMenu}
+            aria-label="Close navigation menu"
+          >
+            <FiX aria-hidden="true" />
+          </button>
           <nav className="pricing-mobile-nav" aria-label="Mobile navigation">
             {navigationItems.map((link) => (
               <a
@@ -134,11 +142,6 @@ const Pricing = () => {
                   aria-pressed={billingCycle === option}
                 >
                   {option}
-                  {option === 'YEARLY' && (
-                    <span className="billing-note" aria-hidden="true">
-                      Best Value!
-                    </span>
-                  )}
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- restyle the Contact Sales CTA and pricing mobile menu to include a close button
- simplify the pricing frequency toggle layout for consistent spacing across viewports
- replace the dashboard mobile sidebar drawer with a full-screen overlay menu and close control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ea1e8b60cc8329aac9ee13fcad0c89