### PR TITLE
Add responsive pricing plan card to Dashvio pricing page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1401,6 +1401,141 @@ a:hover {
   box-shadow: 0 12px 32px rgba(37, 41, 60, 0.3);
 }
 
+.pricing-plan-section {
+  margin-top: 3.5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.pricing-plan-area {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.pricing-plan-card {
+  background: #f6f6fe;
+  border-radius: 16px;
+  border: 1px solid #25293c;
+  padding: 32px;
+  max-width: 420px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: #25293c;
+  transition: opacity 0.3s ease-in-out, transform 0.3s ease, box-shadow 0.3s ease;
+  will-change: transform, opacity;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.pricing-plan-header {
+  display: flex;
+  flex-direction: column;
+}
+
+.pricing-plan-card.fade-out,
+.pricing-plan-card.pre-fade-in,
+.pricing-plan-card.fade-in {
+  opacity: 0;
+  transform: translateY(16px);
+  pointer-events: none;
+}
+
+.pricing-plan-card:hover {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+  transform: translateY(-4px) scale(1.02);
+}
+
+.pricing-plan-card h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  color: #25293c;
+}
+
+.pricing-plan-subtext {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: #9a9a9a;
+}
+
+.pricing-plan-middle {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.pricing-plan-price {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+  color: #25293c;
+}
+
+.pricing-card-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  border-radius: 999px;
+  border: none;
+  background: #7266ed;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.pricing-card-cta:hover,
+.pricing-card-cta:focus-visible {
+  background: #3b3f58;
+  transform: translateY(-1px);
+}
+
+.pricing-plan-features {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pricing-plan-included {
+  margin: 12px 0 0;
+  font-size: 14px;
+  letter-spacing: 1px;
+  color: #9a9a9a;
+  text-transform: uppercase;
+}
+
+.pricing-plan-feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.feature {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #25293c;
+}
+
+.feature span:first-child {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.feature span:last-child {
+  font-size: 15px;
+}
+
 .pricing-hero-visual {
   position: relative;
   display: flex;
@@ -1435,6 +1570,12 @@ a:hover {
   background: linear-gradient(135deg, rgba(37, 41, 60, 0.95), rgba(255, 0, 180, 0.8));
   opacity: 0.24;
   animation: pricingFloatReverse 9s ease-in-out infinite alternate;
+}
+
+@media (max-width: 1024px) {
+  .animated-bg {
+    display: none;
+  }
 }
 
 @keyframes pricingFloat {
@@ -1497,6 +1638,28 @@ a:hover {
   .pricing-frequency {
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .pricing-plan-section {
+    margin-top: 2.75rem;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+  .pricing-plan-card {
+    padding: 28px;
+  }
+
+  .pricing-plan-card h2 {
+    font-size: 18px;
+  }
+
+  .pricing-plan-price {
+    font-size: 28px;
+  }
+
+  .feature span:last-child {
+    font-size: 14px;
   }
 }
 
@@ -1598,6 +1761,35 @@ a:hover {
 
   .pricing-frequency {
     width: 100%;
+  }
+
+  .pricing-plan-section {
+    margin-top: 2.5rem;
+  }
+
+  .pricing-plan-area {
+    justify-content: center;
+  }
+
+  .pricing-plan-card {
+    width: 90vw;
+    padding: 20px;
+  }
+
+  .pricing-plan-card:hover {
+    transform: translateY(-2px);
+  }
+
+  .pricing-plan-card h2 {
+    font-size: 18px;
+  }
+
+  .pricing-plan-price {
+    font-size: 26px;
+  }
+
+  .feature span:last-child {
+    font-size: 14px;
   }
 }
 

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -4,6 +4,31 @@ import BrandLogo from '../components/BrandLogo.jsx';
 
 const BILLING_OPTIONS = ['MONTHLY', 'QUARTERLY', 'YEARLY'];
 
+const PLAN_DETAILS = {
+  MONTHLY: {
+    duration: '1 Month',
+    price: '₹999/mo'
+  },
+  QUARTERLY: {
+    duration: '3 Months',
+    price: '₹316.35/mo'
+  },
+  YEARLY: {
+    duration: '12 Months',
+    price: '₹74.91/mo'
+  }
+};
+
+const PLAN_FEATURES = [
+  'insights of sales and revenue',
+  'returns and settlements',
+  'overview of account health',
+  'Unlimited feature flags',
+  'Web Experimentation',
+  'Access to community and academy',
+  'overall highlights and low lights of your account'
+];
+
 const navLinks = [
   { label: 'Home', href: '/login' },
   { label: 'Solutions', href: '#' },
@@ -15,6 +40,8 @@ const Pricing = () => {
   const [billingCycle, setBillingCycle] = useState('YEARLY');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [displayCycle, setDisplayCycle] = useState('YEARLY');
+  const [transitionState, setTransitionState] = useState('visible');
 
   useEffect(() => {
     const handleScroll = () => {
@@ -61,6 +88,39 @@ const Pricing = () => {
   const handleOptionClick = (option) => {
     setBillingCycle(option);
   };
+
+  useEffect(() => {
+    if (billingCycle !== displayCycle && transitionState === 'visible') {
+      setTransitionState('fade-out');
+    }
+  }, [billingCycle, displayCycle, transitionState]);
+
+  useEffect(() => {
+    let timeoutId;
+
+    if (transitionState === 'fade-out') {
+      timeoutId = setTimeout(() => {
+        setDisplayCycle(billingCycle);
+        setTransitionState('pre-fade-in');
+      }, 260);
+    } else if (transitionState === 'pre-fade-in') {
+      timeoutId = setTimeout(() => {
+        setTransitionState('fade-in');
+      }, 20);
+    } else if (transitionState === 'fade-in') {
+      timeoutId = setTimeout(() => {
+        setTransitionState('visible');
+      }, 20);
+    }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [transitionState, billingCycle]);
+
+  const planDetails = PLAN_DETAILS[displayCycle];
 
   return (
     <div className="pricing-page">
@@ -146,8 +206,35 @@ const Pricing = () => {
               ))}
             </div>
           </div>
-          <div className="pricing-hero-visual" aria-hidden="true">
+          <div className="pricing-hero-visual animated-bg" aria-hidden="true">
             <div className="pricing-ribbons" />
+          </div>
+        </section>
+        <section className="pricing-plan-section" aria-live="polite">
+          <div className="pricing-plan-area">
+            <article className={`pricing-plan-card ${transitionState}`}>
+              <header className="pricing-plan-header">
+                <h2>{planDetails.duration}</h2>
+                <p className="pricing-plan-subtext">Starting at</p>
+              </header>
+              <div className="pricing-plan-middle">
+                <p className="pricing-plan-price">{planDetails.price}</p>
+                <button type="button" className="pricing-card-cta">
+                  Contact Sales
+                </button>
+              </div>
+              <div className="pricing-plan-features">
+                <p className="pricing-plan-included">What's included:</p>
+                <ul className="pricing-plan-feature-list">
+                  {PLAN_FEATURES.map((feature) => (
+                    <li key={feature} className="feature">
+                      <span aria-hidden="true">✓</span>
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </article>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- add a dynamic pricing plan card driven by the billing frequency toggle on the pricing page
- style the plan card with feature list, CTA button, and hover/transition effects that match the Dashvio theme
- enhance responsive behavior, including hiding the animated hero ribbons on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ea2e793cc083298f85f2e8b71bee09