### PR TITLE
Adjust pricing page spacing and responsiveness

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1325,15 +1325,15 @@ a:hover {
 }
 
 .pricing-main {
-  padding: 4.5rem 2.5rem 4rem;
+  padding: 3.75rem 2.25rem 3.25rem;
 }
 
 .pricing-hero {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: center;
-  gap: 3rem;
-  min-height: 80vh;
+  gap: 2.5rem;
+  min-height: min(68vh, 720px);
 }
 
 .pricing-hero-copy {
@@ -1373,7 +1373,7 @@ a:hover {
   border: 1px solid #dcdcf7;
   border-radius: 999px;
   padding: 0.5rem;
-  gap: 0.5rem;
+  gap: 0.45rem;
   width: min(440px, 100%);
   box-shadow: 0 18px 40px rgba(114, 103, 240, 0.08);
 }
@@ -1385,9 +1385,11 @@ a:hover {
   background: #ffffff;
   color: #25293c;
   font-weight: 600;
-  padding: 0.85rem 1.25rem;
+  padding: 0.82rem 1.2rem;
   cursor: pointer;
   transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
+  white-space: nowrap;
+  line-height: 1.05;
 }
 
 .billing-option:hover,
@@ -1402,7 +1404,7 @@ a:hover {
 }
 
 .pricing-plan-section {
-  margin-top: 3.5rem;
+  margin-top: 2.5rem;
   display: flex;
   justify-content: center;
 }
@@ -1411,14 +1413,17 @@ a:hover {
   display: flex;
   justify-content: center;
   width: 100%;
+  max-width: min(1120px, 100%);
+  padding-inline: 1.5rem;
+  margin: 0 auto;
 }
 
 .pricing-plan-card {
-  background: #f6f6fe;
+  background: #ffffff;
   border-radius: 16px;
-  border: 1px solid #25293c;
+  border: 1.5px solid #25293c;
   padding: 32px;
-  max-width: 420px;
+  max-width: none;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -1426,7 +1431,7 @@ a:hover {
   color: #25293c;
   transition: opacity 0.3s ease-in-out, transform 0.3s ease, box-shadow 0.3s ease;
   will-change: transform, opacity;
-  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.05);
   opacity: 1;
   transform: translate3d(0, 0, 0);
 }
@@ -1445,7 +1450,7 @@ a:hover {
 }
 
 .pricing-plan-card:hover {
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.08);
   transform: translateY(-4px) scale(1.02);
 }
 
@@ -1618,13 +1623,14 @@ a:hover {
   }
 
   .pricing-main {
-    padding: 4rem 1.75rem 3.5rem;
+    padding: 3.25rem 1.6rem 3rem;
   }
 
   .pricing-hero {
     grid-template-columns: 1fr;
     text-align: center;
-    gap: 2.75rem;
+    gap: 2.25rem;
+    min-height: unset;
   }
 
   .pricing-hero-copy {
@@ -1641,7 +1647,11 @@ a:hover {
   }
 
   .pricing-plan-section {
-    margin-top: 2.75rem;
+    margin-top: 2.25rem;
+  }
+
+  .pricing-plan-area {
+    padding-inline: 1rem;
   }
 }
 
@@ -1748,11 +1758,12 @@ a:hover {
   }
 
   .pricing-main {
-    padding: 3.25rem 1.25rem 3.25rem;
+    padding: 2.9rem 1.15rem 2.9rem;
   }
 
   .pricing-hero {
-    min-height: calc(100vh - 120px);
+    min-height: unset;
+    gap: 2rem;
   }
 
   .pricing-hero-copy h1 {
@@ -1764,16 +1775,17 @@ a:hover {
   }
 
   .pricing-plan-section {
-    margin-top: 2.5rem;
+    margin-top: 2.1rem;
   }
 
   .pricing-plan-area {
     justify-content: center;
+    padding-inline: 0.75rem;
   }
 
   .pricing-plan-card {
-    width: 90vw;
-    padding: 20px;
+    width: 100%;
+    padding: 24px;
   }
 
   .pricing-plan-card:hover {
@@ -1811,9 +1823,9 @@ a:hover {
   }
 
   .billing-option {
-    font-size: 0.95rem;
-    padding-inline: 0.85rem;
-    padding-block: 0.75rem;
+    font-size: 0.92rem;
+    padding-inline: 0.82rem;
+    padding-block: 0.7rem;
   }
 }
 
@@ -1828,6 +1840,16 @@ a:hover {
 
   .pricing-hero-copy h1 {
     font-size: clamp(1.95rem, 9vw, 2.35rem);
+  }
+
+  .pricing-frequency {
+    gap: 0.35rem;
+    padding: 0.45rem;
+  }
+
+  .billing-option {
+    font-size: 0.86rem;
+    padding-inline: 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten the vertical spacing between the hero and pricing sections for desktop, tablet, and mobile layouts
- expand the pricing plan card to better fill the available space and reinforce the border styling
- adjust billing toggle sizing so text stays within the pills on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68ea3e5beeb88329aa0ba1e487f9a4c0